### PR TITLE
Improve the benchmarking code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tracing = "0.1.34"
 [dev-dependencies]
 criterion = { version = "0.4", features = ["async_tokio"] }
 futures = "0.3.25"
-moka = { version = "0.9", features = [ "future"] }
+moka = { version = "0.10", features = [ "future"] }
 rand = "0.8.5"
 tokio-test = "0.4.2"
 

--- a/benches/deduplicate.rs
+++ b/benches/deduplicate.rs
@@ -1,8 +1,13 @@
+use std::sync::{
+    atomic::{self, AtomicU64},
+    Arc,
+};
+
 use deduplicate::Deduplicate;
 use deduplicate::DeduplicateFuture;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use moka::future::Cache;
+use moka::future::{Cache, ConcurrentCacheExt};
 use rand::{thread_rng, Rng};
 
 // Utility function for loading a vec of strings from disk
@@ -27,8 +32,8 @@ fn cache_get(c: &mut Criterion) {
     // It's deliberately slow (loads words every time it's called)
     // to illustrate that missing caches is expensive...
     let getter = move |key: String| -> DeduplicateFuture<String> {
-        let words = get_text();
         let fut = async move {
+            let words = get_text();
             for word in words {
                 if key == *word {
                     return Some("Found It".to_string());
@@ -44,9 +49,10 @@ fn cache_get(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("get");
     // 0% = 0, 5% = 512, 10% = 1024, 20% = 2048, 40% = 4096, 80% = 8192
-    for size in [0, 512, 1024, 2048, 4096, 8192].iter() {
+    for size in [0, 64, 128, 256, 512, 1024, 2048, 4096, 8192].iter() {
         // Benchmark deduplicate
         let deduplicate = Deduplicate::with_capacity(getter, *size);
+        let get_count = Arc::new(AtomicU64::default());
         group.bench_with_input(
             BenchmarkId::new("deduplicate get", size),
             &words,
@@ -55,23 +61,56 @@ fn cache_get(c: &mut Criterion) {
                     .iter(|| async {
                         let word = &words[thread_rng().gen_range(0..words.len())];
                         let _ = deduplicate.get(word.to_string()).await;
+                        get_count.fetch_add(1, atomic::Ordering::AcqRel);
                     })
             },
         );
-        eprintln!("deduplicate cache used: {}", deduplicate.count());
+        let get_count = get_count.load(atomic::Ordering::Acquire);
+        eprintln!(
+            "deduplicate cache used - count: {}, get_count: {}",
+            deduplicate.count(),
+            get_count
+        );
 
         // Benchmark moka
         let moka = Cache::new(*size as u64);
+        let get_count = Arc::new(AtomicU64::default());
+        let hit_count = Arc::new(AtomicU64::default());
         group.bench_with_input(BenchmarkId::new("moka get", size), &words, |b, words| {
             b.to_async(tokio::runtime::Runtime::new().expect("build tokio runtime"))
                 .iter(|| async {
                     let word = &words[thread_rng().gen_range(0..words.len())];
-                    let _ = moka
-                        .optionally_get_with(word.to_string(), getter(word.to_string()))
+                    let maybe_entry = moka
+                        .entry_by_ref(word)
+                        .or_optionally_insert_with(getter(word.to_string()))
                         .await;
+                    match maybe_entry {
+                        Some(entry) if !entry.is_fresh() => {
+                            // Hit
+                            hit_count.fetch_add(1, atomic::Ordering::AcqRel);
+                        }
+                        None | Some(_) => {
+                            (); // Miss
+                        }
+                    }
+                    get_count.fetch_add(1, atomic::Ordering::AcqRel);
+
+                    // Process pending evictions. Without this, moka will hold more
+                    // entries than the max capacity, which will skew the benchmarking
+                    // result by increasing the hit ratio.
+                    moka.sync();
                 })
         });
-        eprintln!("moka cache used: {}", moka.entry_count());
+
+        let get_count = get_count.load(atomic::Ordering::Acquire);
+        let hit_count = hit_count.load(atomic::Ordering::Acquire);
+
+        eprintln!(
+            "moka cache used - entry_count: {}, get_count: {}, hit_ratio: {:.2}%",
+            moka.entry_count(),
+            get_count,
+            hit_count as f64 / get_count as f64 * 100.0,
+        );
     }
 }
 


### PR DESCRIPTION
This PR fixes #1.

- Fix the error causing moka's performance was not improved when the cache size was increased.
- Call moka's `cache.sync()` in every iterations to process pending eviction.
- Show the number of `get` calls in both benchmarks.
- Show the hit ratio (`hit_count` / `get_count`) in moka benchmark.
- Add more cache sizes `64`, `128` and `256` to reduce the hit ratio.
- Upgrade moka to v0.10.0. (Required to track the hit ratio)

See #1 for more details about the above changes.